### PR TITLE
sanat: Add missing permissions for etymologiatoimittaja

### DIFF
--- a/servers/sanat/roles/mediawiki/templates/LocalSettings-sanat.php.j2
+++ b/servers/sanat/roles/mediawiki/templates/LocalSettings-sanat.php.j2
@@ -99,6 +99,7 @@ $wgNamespaceProtection[ NS_EVE ] = [ 'etymologiatoimittaja' ];
 $wgGroupPermissions[ 'etymologiatoimittaja' ][ 'delete' ] = true;
 $wgGroupPermissions[ 'etymologiatoimittaja' ][ 'move' ] = true;
 $wgGroupPermissions[ 'etymologiatoimittaja' ][ 'etymologi' ] = true;
+$wgGroupPermissions[ 'etymologiatoimittaja' ][ 'etymologiatoimittaja' ] = true;
 $wgGroupPermissions[ 'etymologi' ][ 'etymologi' ] = true;
 $wgAddGroups[ 'etymologiatoimittaja' ] = [ 'etymologiatoimittaja', 'etymologi' ];
 


### PR DESCRIPTION
The group etymologiatoimittaja needs the right etymologiatoimittaja to
edit the namespace EVE.