### PR TITLE
Enable spam tools on all wikis

### DIFF
--- a/servers/sanat/roles/mediawiki/templates/LocalSettings-nimiarkisto.php.j2
+++ b/servers/sanat/roles/mediawiki/templates/LocalSettings-nimiarkisto.php.j2
@@ -108,14 +108,9 @@ for ( $i = 0; $i < 100000; $i++ ) {
 	$wgNamespaceProtection[$i] = 'alledit';
 }
 
-wfLoadExtension( 'Nuke' );
-require_once "$IP/extensions/SmiteSpam/SmiteSpam.php";
-$wgDisplayPageSize = 10;
-
 wfLoadExtension( 'WikiEditor' );
 $wgDefaultUserOptions['usebetatoolbar'] = 1;
 wfLoadExtension( 'CodeEditor' );
-
 
 wfLoadExtension( 'FileSystemImageServer' );
 $wgFSISGroups['Kotus'] = [

--- a/servers/sanat/roles/mediawiki/templates/LocalSettings-termipankki.php.j2
+++ b/servers/sanat/roles/mediawiki/templates/LocalSettings-termipankki.php.j2
@@ -107,7 +107,6 @@ wfLoadExtension( 'HeaderTabs' );
 wfLoadExtension( 'InputBox' );
 wfLoadExtension( 'LiquidThreads' );
 wfLoadExtension( 'MixedNamespaceSearchSuggestions' );
-wfLoadExtension( 'Nuke' );
 wfLoadExtension( 'PageForms' );
 $wgPageFormsRenameEditTabs = true;
 $wgPageForms24HourTime = true;
@@ -171,8 +170,6 @@ $wgHooks['TranslatePostInitGroups'][] = function ( &$list, &$deps, &$autoload ) 
 };
 
 wfLoadExtension( 'UniversalLanguageSelector' );
-wfLoadExtension( 'UserMerge' );
-$wgGroupPermissions['bureaucrat']['usermerge'] = true;
 
 wfLoadExtension( 'WikiEditor' );
 $wgDefaultUserOptions['usebetatoolbar'] = 1;

--- a/servers/sanat/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/servers/sanat/roles/mediawiki/templates/LocalSettings.php.j2
@@ -120,6 +120,13 @@ require __DIR__ . "/LocalSettings-$VHOST.php";
 // $wgSearchType = 'CirrusSearch';
 // $wgCirrusSearchExtraIndexSettings['index.mapping.total_fields.limit'] = 5000;
 
+// Spam tools
+wfLoadExtension( 'Nuke' );
+wfLoadExtension( 'UserMerge' );
+$wgGroupPermissions['bureaucrat']['usermerge'] = true;
+require_once "$IP/extensions/SmiteSpam/SmiteSpam.php";
+$wgDisplayPageSize = 10;
+
 {% if nocaptcha is defined %}
 wfLoadExtensions( [ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ] );
 $wgReCaptchaSiteKey = '{{ nocaptcha.site }}';


### PR DESCRIPTION
SmiteSpam and UserMerge are required by my spam removal script (not included), and Nuke just for consistency.