### PR TITLE
Install SpamBlacklist extension for sanat

### DIFF
--- a/servers/sanat/roles/mediawiki/files/co_repos
+++ b/servers/sanat/roles/mediawiki/files/co_repos
@@ -36,6 +36,7 @@ REPOS=(
 	"workdir/extensions/ShortUrl https://github.com/wikimedia/mediawiki-extensions-ShortUrl.git origin/REL1_31"
 	"workdir/extensions/SimpleMathJax https://github.com/jmnote/SimpleMathJax.git 65f9814" # 1.31-pre
 	"workdir/extensions/SmiteSpam https://github.com/wikimedia/mediawiki-extensions-SmiteSpam origin/master"
+	"workdir/extensions/SpamBlacklist https://github.com/wikimedia/mediawiki-extensions-SpamBlacklist origin/REL1_31"
 	"workdir/extensions/Termbank https://github.com/Nikerabbit/mediawiki-extensions-Termbank.git origin/master"
 	"workdir/extensions/Translate https://github.com/wikimedia/mediawiki-extensions-Translate.git 2019.04"
 	"workdir/extensions/UniversalLanguageSelector https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector.git 2019.04"

--- a/servers/sanat/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/servers/sanat/roles/mediawiki/templates/LocalSettings.php.j2
@@ -126,6 +126,19 @@ wfLoadExtension( 'UserMerge' );
 $wgGroupPermissions['bureaucrat']['usermerge'] = true;
 require_once "$IP/extensions/SmiteSpam/SmiteSpam.php";
 $wgDisplayPageSize = 10;
+wfLoadExtension( 'SpamBlacklist' );
+$wgBlacklistSettings = [
+        'spam' => [
+                'files' => [
+                        '/srv/mediawiki/spam-filter.txt',
+                ],
+        ],
+        'email' => [
+                'files' =>  [
+                        '/srv/mediawiki/email-filter.txt',
+                ],
+        ],
+];
 
 {% if nocaptcha is defined %}
 wfLoadExtensions( [ 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ] );


### PR DESCRIPTION
Main use case is to prevent certain emails domains to be used when
registering a new account.