### PR TITLE
KP-5755 Check the installation after installing tagtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 servers/sanat/.idea/*
 *.retry
+*.sw?

--- a/commandline/roles/finnish-tagtools/tasks/main.yml
+++ b/commandline/roles/finnish-tagtools/tasks/main.yml
@@ -37,3 +37,10 @@
     - "{{ tagtools_install_dir }}"
     - "{{ module_path }}"
   when: shared_group is defined
+
+- name: Run make check-installed
+  make:
+    chdir: "{{ compile_dir }}"
+    target: check-installed
+    params:
+      prefix: "{{ tagtools_install_dir }}"

--- a/commandline/roles/finnish-tagtools/tasks/main.yml
+++ b/commandline/roles/finnish-tagtools/tasks/main.yml
@@ -7,10 +7,10 @@
     - "{{ tagtools_install_dir }}"
     - "{{ tagtools_install_dir }}/bin"
     - "{{ compile_root }}"
-    
+
 - name: Unpack from tar
   unarchive:
-    src: "{{ tagtools_tar}}"
+    src: "{{ tagtools_tar }}"
     dest: "{{ compile_root }}"
     remote_src: yes
 
@@ -27,7 +27,6 @@
     dest: "{{ module_path }}/{{ version }}.lua"
     mode: 0644
 
-      
 - name: Fix permissions (if shared group is set)
   file:
     path: "{{ item }}"


### PR DESCRIPTION
Now our Ansible runs `make check-installed` after installing finnish-tagtools. This should detect if the software is being deployed with missing or broken dependencies.