### PR TITLE
KP-5755 Add instructions / modifications for local installation

### DIFF
--- a/commandline/README.md
+++ b/commandline/README.md
@@ -22,6 +22,30 @@ remind that installs are targeted at Taito.
 
 ansible-playbook -i test site.yml -e "target_host=taito"
 
+## Local installation
+
+It is possible to install the tools on a local machine to test the scripts, but this still needs some manual work. Below are the extra steps needed on a Ubuntu machine.
+
+```
+# create directory that corresponds to install_prefix
+sudo mkdir /data
+sudo chmod 0777 /data
+
+# debian dependencies for hfst-ospell
+sudo apt installlibxml++2.6-dev libarchive-dev
+# alternatives
+libxml++2 libarchive
+
+# dependencies for finnish-parse
+sudo apt install opennlp
+
+# the hfst installation location must be in path so that is discovered when testing finnish-tagtools
+export PATH="/data/ling/hfst/3.16.0/bin:$PATH"
+
+# run the playbook locally (set python version to match yours)
+ansible-playbook site.yml -i inventories/localhost --connection=local --extra-vars "python3_base_version=3.8"
+```
+
 # Production
 
 In production the installation target is Kielipankki's software

--- a/commandline/README.md
+++ b/commandline/README.md
@@ -24,27 +24,31 @@ ansible-playbook -i test site.yml -e "target_host=taito"
 
 ## Local installation
 
-It is possible to install the tools on a local machine to test the scripts, but this still needs some manual work. Below are the extra steps needed on a Ubuntu machine.
+It is possible to install the tools on a local machine to test the scripts, but this still needs some manual work. With these instructions, it is possible to run most of the site.yml on a local Ubuntu machine: finnish-parse must be skipped due to its installation script being outdated, and at least on a virtual machine with frugal amount of memory, kaldi compilation will not succeed.
+
+Below are the steps needed:
 
 ```
 # create directory that corresponds to install_prefix
 sudo mkdir /data
 sudo chmod 0777 /data
 
-# debian dependencies for hfst-ospell
-sudo apt installlibxml++2.6-dev libarchive-dev
-# alternatives
+# debian dependencies for hfst
+sudo apt install libxml++2.6-dev libarchive-dev autoconf libtool libreadline-dev swig
+# some alternatives for other systems
 libxml++2 libarchive
 
 # dependencies for finnish-parse
 sudo apt install opennlp
 
-# the hfst installation location must be in path so that is discovered when testing finnish-tagtools
-export PATH="/data/ling/hfst/3.16.0/bin:$PATH"
+# the hfst and tagtools installation locations must be in path so that is discovered when testing finnish-tagtools
+export PATH="/data/ling/hfst/3.16.0/bin:/data/ling/finnish-tagtools/1.6.0/bin:$PATH"
 
 # run the playbook locally (set python version to match yours)
 ansible-playbook site.yml -i inventories/localhost --connection=local --extra-vars "python3_base_version=3.8"
 ```
+
+A long term solution is to adjust the roles and/or the invocation (e.g. use of `is_admin`) to make these extra steps unnecessary.
 
 # Production
 

--- a/commandline/inventories/localhost
+++ b/commandline/inventories/localhost
@@ -1,9 +1,11 @@
 hpc:
   hosts:
     localhost:
-      compile_dir: /tmp/{{ansible_user_id}}
       module_root: /tmp/{{ansible_user_id}}/ansible/modulefiles
       install_prefix: /data
       kielipankki_data_dir: /tmp/{{ansible_user_id}}/ansible/kielipankki_data
       is_admin: false
       swig3_as_module: yes
+      python_swig_modcall: ""
+      python_modcall: ""
+      compiler_call: ""

--- a/commandline/roles/finnish-tagtools/tasks/main.yml
+++ b/commandline/roles/finnish-tagtools/tasks/main.yml
@@ -7,6 +7,7 @@
     - "{{ tagtools_install_dir }}"
     - "{{ tagtools_install_dir }}/bin"
     - "{{ compile_root }}"
+    - "{{ module_path }}"
 
 - name: Unpack from tar
   unarchive:

--- a/commandline/roles/finnish-tagtools/templates/module_template.j2
+++ b/commandline/roles/finnish-tagtools/templates/module_template.j2
@@ -1,0 +1,11 @@
+-- This is the module file for {{ package_name }}
+
+help([[
+         {{ package_name }} {{ version }}
+]])
+
+local   version =       '{{ version }}'
+local   prog_root =     '{{ install_prefix }}/ling/{{ package_name }}'
+
+prepend_path('PATH', pathJoin(prog_root,version,'bin'))
+

--- a/commandline/roles/hfst-ospell/tasks/main.yml
+++ b/commandline/roles/hfst-ospell/tasks/main.yml
@@ -11,7 +11,7 @@
     - is_admin
 
 - name: "RHEL/CentOS: Install list of packages"
-  yum: 
+  yum:
     name:
     - libxml++2.6-dev # check name!
     state: present
@@ -40,19 +40,19 @@
     chdir: "{{ compile_dir }}"
     creates: libtool
 
-- name: Running ./configure 
+- name: Running ./configure
   command: "./configure --enable-hfst-ospell-office=no "
   args:
     chdir: "{{ compile_dir }}"
     creates: config.log
 
-- name: Running make 
+- name: Running make
   shell: "make > MAKE.log"
   args:
     chdir: "{{ compile_dir }}"
     creates: MAKE.log
 
-- name: Running  make check 
+- name: Running  make check
   shell: "make check -j 4 > MAKE_CHECK.log"
   args:
     chdir: "{{ compile_dir }}"

--- a/commandline/roles/hfst/handlers/main.yml
+++ b/commandline/roles/hfst/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: Update ldconfig
+  shell: ldconfig
+  become: yes

--- a/commandline/roles/hfst/tasks/main.yml
+++ b/commandline/roles/hfst/tasks/main.yml
@@ -154,6 +154,11 @@
   args:
     chdir: "{{ hfst_compile_dir }}/python/test"
 
+- name: Create modulefile installation directory
+  file:
+    path: "{{ module_path }}"
+    state: directory
+
 - name: Install modulefile
   template:
     src: module_template.j2

--- a/commandline/roles/hfst/tasks/main.yml
+++ b/commandline/roles/hfst/tasks/main.yml
@@ -149,6 +149,17 @@
   args:
     chdir: "{{ hfst_compile_dir }}/python"
 
+- name: Add hfst path to library directories
+  copy:
+    dest: "/etc/ld.so.conf.d/libhfst.conf"
+    content: "{{ hfst_install_dir }}/lib"
+  become: yes
+  notify: Update ldconfig
+  when: inventory_hostname == 'localhost'
+
+- name: Flush handlers to ensure that ldconfig is run before checking the module
+  meta: flush_handlers
+
 - name: Checking python module
   shell: bash --login -c  "{{ python_modcall }} LD_LIBRARY_PATH={{ hfst_install_dir }}/lib/:$LD_LIBRARY_PATH && ./test.sh --python python3 --pythonpath {{ hfst_install_dir }}/lib/python{{ python3_base_version }}/site-packages --verbose"
   args:

--- a/commandline/roles/kaldi/tasks/main.yml
+++ b/commandline/roles/kaldi/tasks/main.yml
@@ -7,6 +7,8 @@
     - subversion
     - libatlas-dev
     - libatlas-base-dev
+    - sox
+    - gfortran
     state: present
   become: yes
   when:


### PR DESCRIPTION
Not quite everything is yet installable locally, but at least the roles up to kaldi (not enough memory for compilation on a frugal VM) in site.yml work, except finnish-parse (whose installation script contains outdated links). The readme contains instructions that outline the extra steps required on a local Ubuntu.