### PR TITLE
KP-5971 Get sertificate for sanat.csc.fi from ACME

### DIFF
--- a/servers/sanat/group_vars/all.yml
+++ b/servers/sanat/group_vars/all.yml
@@ -23,9 +23,12 @@ apache_ssl_cipher_suite: "\
 
 certificate_path: /etc/pki/tls
 
-ssl_params_sanat:
-  certificate_file: "{{ certificate_path }}/certs/{{ webdomain_sanat }}.crt"
-  certificate_key_file: "{{ certificate_path }}/private/{{ webdomain_sanat }}.key"
+acme_root: /etc/letsencrypt
+acme_endpoint: "https://acme.sectigo.com/v2/OV"
+acme_email: ling-admin@listat.csc.fi
+acme_keyid: "{{ lookup('passwordstore', 'lb_passwords/portal/acme_keyid') }}"
+acme_hmac: "{{ lookup('passwordstore', 'lb_passwords/portal/acme_hmac') }}"
+
 ssl_params_nimiarkisto:
   certificate_file: "{{ certificate_path }}/certs/{{ webdomain_nimiarkisto }}.crt"
   certificate_key_file: "{{ certificate_path }}/private/{{ webdomain_nimiarkisto }}.key"

--- a/servers/sanat/roles/apache_ssl/handlers/main.yml
+++ b/servers/sanat/roles/apache_ssl/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: restart httpd
+  service: name=httpd state=restarted enabled=yes
+  become: yes

--- a/servers/sanat/roles/apache_ssl/tasks/main.yml
+++ b/servers/sanat/roles/apache_ssl/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Copy vhost.conf
   template:
-    src: "ssl.conf.j2"
-    dest: "/etc/httpd/conf.d/vhost.conf"
+    src: "vhosts.conf.j2"
+    dest: "/etc/httpd/conf.d/vhosts.conf"
   notify: restart httpd
   become: yes

--- a/servers/sanat/roles/apache_ssl/tasks/main.yml
+++ b/servers/sanat/roles/apache_ssl/tasks/main.yml
@@ -1,12 +1,47 @@
-# You should place the proper certs on the server directly. This wont replace it.
+---
 
-- name: Install openssl
-  package:
-    name: openssl
+- name: Install required packages
+  yum:
+    name:
+      - httpd
+      - mod_ssl
+      - certbot
+      - python*-certbot-apache
+      - logrotate
     state: present
+  become: yes
 
-# TODO: This does not handle aliases
-- name: Create self-signed SSL certificate
-  command: openssl req -new -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN={{ item.servername }}" -days 365 -keyout {{ item.certificate_key_file }} -out {{ item.certificate_file }} -extensions v3_ca creates={{ item.certificate_key_file }}
-  notify: restart apache
-  with_items: "{{ apache_vhosts_ssl }}"
+- name: Register ACME
+  shell:
+    cmd: >
+      certbot register --server {{ acme_endpoint }}
+      --agree-tos --eab-kid {{ acme_keyid }}
+      --eab-hmac-key {{ acme_hmac }}
+      --no-eff-email
+      --email {{ acme_email }}
+    creates: "{{ acme_root }}/accounts/acme.sectigo.com/v2/OV/"
+  become: yes
+
+- name: Fetch certificate via ACME
+  shell:
+    cmd: >
+      certbot certonly --apache --server {{ acme_endpoint }}
+      --non-interactive --agree-tos --domain signbank.csc.fi
+  become: yes
+
+- name: Setup weekly cronjob for updating the certificate
+  copy:
+    dest: /etc/cron.weekly/renew-cert
+    mode: 0755
+    content: |
+      #!/bin/bash
+      # See https://wiki.csc.fi/PATA/Ohjeet/ServerCertificatesACME
+      certbot renew --deploy-hook "systemctl reload httpd"
+  become: yes
+
+- name: Copy vhost.conf
+  template:
+    src: "ssl.conf.j2"
+    dest: "/etc/httpd/conf.d/vhost.conf"
+  notify: restart httpd
+  become: yes

--- a/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
+++ b/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
@@ -61,7 +61,7 @@ RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
   SSLHonorCipherOrder On
   SSLCompression off
   SSLCertificateFile  "{{ acme_root }}/live/sanat.csc.fi/cert.pem"
-SSLCertificateKeyFile "{{ acme_root }}/live/sanat.csc.fi/privkey.pem"
+  SSLCertificateKeyFile "{{ acme_root }}/live/sanat.csc.fi/privkey.pem"
   SSLCertificateChainFile  "{{ acme_root }}/live/sanat.csc.fi/chain.pem"
 
   <Directory "/www/sanat.csc.fi/docroot">

--- a/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
+++ b/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
@@ -1,0 +1,166 @@
+DirectoryIndex index.php index.html
+
+
+<VirtualHost *:80>
+  ServerName sanat.csc.fi
+  ServerAlias 
+  DocumentRoot "/www/sanat.csc.fi/docroot"
+
+  <Directory "/www/sanat.csc.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+RewriteEngine On
+RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName nimiarkisto.fi
+  ServerAlias namnarkivet.fi nammaarkiiva.fi xn--nommarkkdh-64aeb.fi nommaarkkadah.fi xn--nmmarkiiv-q7a.fi nommarkiiv.fi www.nimiarkisto.fi www.namnarkivet.fi www.nammaarkiiva.fi www.xn--nommarkkdh-64aeb.fi www.nommaarkkadah.fi www.xn--nmmarkiiv-q7a.fi www.nommarkiiv.fi
+  DocumentRoot "/www/nimiarkisto.fi/docroot"
+
+  <Directory "/www/nimiarkisto.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+RewriteEngine On
+RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+
+</VirtualHost>
+
+<VirtualHost *:80>
+  ServerName tieteentermipankki.fi
+  ServerAlias www.tieteentermipankki.fi
+  DocumentRoot "/www/tieteentermipankki.fi/docroot"
+
+  <Directory "/www/tieteentermipankki.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+RewriteEngine On
+RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+
+</VirtualHost>
+
+
+<VirtualHost *:443>
+  ServerName sanat.csc.fi
+  ServerAlias 
+  DocumentRoot "/www/sanat.csc.fi/docroot"
+
+  SSLEngine on
+  SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+  SSLHonorCipherOrder On
+  SSLCompression off
+  SSLCertificateFile  "{{ acme_root }}/live/sanat.csc.fi/cert.pem"
+SSLCertificateKeyFile "{{ acme_root }}/live/sanat.csc.fi/privkey.pem"
+  SSLCertificateChainFile  "{{ acme_root }}/live/sanat.csc.fi/chain.pem"
+
+  <Directory "/www/sanat.csc.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+Header always set Strict-Transport-Security "max-age=15768000"
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://localhost:9000/www/sanat.csc.fi/docroot/"
+
+</VirtualHost>
+
+<VirtualHost *:443>
+  ServerName nimiarkisto.fi
+  ServerAlias namnarkivet.fi nammaarkiiva.fi xn--nommarkkdh-64aeb.fi nommaarkkadah.fi xn--nmmarkiiv-q7a.fi nommarkiiv.fi www.nimiarkisto.fi www.namnarkivet.fi www.nammaarkiiva.fi www.xn--nommarkkdh-64aeb.fi www.nommaarkkadah.fi www.xn--nmmarkiiv-q7a.fi www.nommarkiiv.fi
+  DocumentRoot "/www/nimiarkisto.fi/docroot"
+
+  SSLEngine on
+  SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+  SSLHonorCipherOrder On
+  SSLCompression off
+  SSLCertificateFile /etc/pki/tls/certs/nimiarkisto_fi_cert.cer
+  SSLCertificateKeyFile /etc/pki/tls/private/nimiarkisto_fi.key
+  SSLCertificateChainFile /etc/pki/tls/certs/GEANT_OV_RSA_CA_4.cer
+
+  <Directory "/www/nimiarkisto.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+<Location "/reconciliation/">
+  ProxyPass         "http://95.216.176.62:8484/"
+  ProxyPassReverse  "http://95.216.176.62:8484/"
+</Location>
+
+<Location "/query/">
+  ProxyPass         "http://95.216.176.62:8282/"
+  ProxyPassReverse  "http://95.216.176.62:8282/"
+</Location>
+
+<Location "/proxy/">
+  ProxyPass         "http://95.216.176.62:8282/proxy/"
+</Location>
+
+<Location "/openrefine/">
+  ProxyPass         "http://95.216.176.62:3333/"
+</Location>
+
+<Location "/quickstatements/">
+  ProxyPass         "http://95.216.176.62:9191/"
+</Location>
+
+Header always set Strict-Transport-Security "max-age=15768000"
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://localhost:9000/www/nimiarkisto.fi/docroot/"
+
+RewriteEngine On
+RewriteRule ^/entity/(Q.*) /wiki/Item:$1 [R]
+RewriteRule ^/entity/(P.*) /wiki/Wikibase_property:$1 [R]
+# Drop www prefix
+RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
+
+</VirtualHost>
+
+<VirtualHost *:443>
+  ServerName tieteentermipankki.fi
+  ServerAlias www.tieteentermipankki.fi
+  DocumentRoot "/www/tieteentermipankki.fi/docroot"
+
+  SSLEngine on
+  SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+  SSLHonorCipherOrder On
+  SSLCompression off
+  SSLCertificateFile /etc/pki/tls/certs/www_tieteentermipankki_fi_cert.cer
+  SSLCertificateKeyFile /etc/pki/tls/private/www_tieteentermipankki_fi.key
+  SSLCertificateChainFile /etc/pki/tls/certs/GEANT_OV_RSA_CA_4.cer
+
+  <Directory "/www/tieteentermipankki.fi/docroot">
+    AllowOverride All
+    Options -Indexes +FollowSymLinks
+    Require all granted
+  </Directory>
+  
+Header always set Strict-Transport-Security "max-age=15768000"
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://localhost:9000/www/tieteentermipankki.fi/docroot/"
+
+RewriteEngine On
+# Drop www prefix
+RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
+# This will redirect anyway, so use internal redirect
+RewriteRule ^/!(.*) /wiki/Special:ShortUrl/$1 [PT]
+
+</VirtualHost>
+


### PR DESCRIPTION
Previously vhost.conf was not managed by Ansible. The current conf from the site was translated into a Jinja template and is now managed by Ansible.

The certificates for the other two sites residing on this machine were not altered, nor was their configuration.

Dry-running only the apache configuration role using a custom inventory without the vaulted secrets produces the following diff:
```
vagrant@kpdev:~/scratch/Kielipankki-palvelut/servers/sanat$ ansible-playbook apache-only.yml --check -i inventories/production --private-key ~/.ssh/id_rsa_kielipankki --diff

PLAY [web] ******************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************
Enter passphrase for key '/home/vagrant/.ssh/id_rsa_kielipankki': 
Enter passphrase for key '/home/vagrant/.ssh/id_rsa_kielipankki': 
ok: [sanat.csc.fi]

TASK [apache_ssl : Install required packages] *******************************************************************************
changed: [sanat.csc.fi]

TASK [apache_ssl : Register ACME] *******************************************************************************************
changed: [sanat.csc.fi]

TASK [apache_ssl : Fetch certificate via ACME] ******************************************************************************
skipping: [sanat.csc.fi]

TASK [apache_ssl : Setup weekly cronjob for updating the certificate] *******************************************************
--- before
+++ after: /home/vagrant/.ansible/tmp/ansible-local-258071f0xjdf2/tmpoipkmk98
@@ -0,0 +1,3 @@
+#!/bin/bash
+# See https://wiki.csc.fi/PATA/Ohjeet/ServerCertificatesACME
+certbot renew --deploy-hook "systemctl reload httpd"

changed: [sanat.csc.fi]

TASK [apache_ssl : Copy vhost.conf] *****************************************************************************************
--- before: /etc/httpd/conf.d/vhosts.conf
+++ after: /home/vagrant/.ansible/tmp/ansible-local-258071f0xjdf2/tmpebxx9riu/vhosts.conf.j2
@@ -60,9 +60,9 @@
   SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
   SSLHonorCipherOrder On
   SSLCompression off
-  SSLCertificateFile /etc/pki/tls/certs/sanat_csc_fi_cert.cer
-  SSLCertificateKeyFile /etc/pki/tls/private/sanat_csc_fi.key
-  SSLCertificateChainFile /etc/pki/tls/certs/GEANT_OV_RSA_CA_4.cer
+  SSLCertificateFile  "/etc/letsencrypt/live/sanat.csc.fi/cert.pem"
+  SSLCertificateKeyFile "/etc/letsencrypt/live/sanat.csc.fi/privkey.pem"
+  SSLCertificateChainFile  "/etc/letsencrypt/live/sanat.csc.fi/chain.pem"
 
   <Directory "/www/sanat.csc.fi/docroot">
     AllowOverride All

changed: [sanat.csc.fi]

RUNNING HANDLER [apache_ssl : restart httpd] ********************************************************************************
changed: [sanat.csc.fi]

PLAY RECAP ******************************************************************************************************************
sanat.csc.fi               : ok=6    changed=5    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
```