### PR TITLE
KP-5971 Vol 2: Fix domain (copypaste error)

### DIFF
--- a/servers/sanat/roles/apache_ssl/tasks/main.yml
+++ b/servers/sanat/roles/apache_ssl/tasks/main.yml
@@ -26,7 +26,7 @@
   shell:
     cmd: >
       certbot certonly --apache --server {{ acme_endpoint }}
-      --non-interactive --agree-tos --domain signbank.csc.fi
+      --non-interactive --agree-tos --domain sanat.csc.fi
   become: yes
 
 - name: Setup weekly cronjob for updating the certificate


### PR DESCRIPTION
A copypaste error slipped through and we tried to fetch the certificate for an irrelevant domain. It's fixed now, and sanat.csc.fi has a new certificate.