### PR TITLE
KP-6041 ACME certificate for tieteentermipankki

### DIFF
--- a/servers/sanat/roles/apache_ssl/tasks/main.yml
+++ b/servers/sanat/roles/apache_ssl/tasks/main.yml
@@ -22,11 +22,17 @@
     creates: "{{ acme_root }}/accounts/acme.sectigo.com/v2/OV/"
   become: yes
 
-- name: Fetch certificate via ACME
+- name: Fetch certificates via ACME
   shell:
     cmd: >
       certbot certonly --apache --server {{ acme_endpoint }}
-      --non-interactive --agree-tos --domain sanat.csc.fi
+      --non-interactive --agree-tos
+      {% for domain in item %}
+      -d  {{ domain }}
+      {% endfor %}
+  loop:
+    - ["sanat.csc.fi"]
+    - ["tieteentermipankki.fi", "www.tieteentermipankki.fi"]
   become: yes
 
 - name: Setup weekly cronjob for updating the certificate

--- a/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
+++ b/servers/sanat/roles/apache_ssl/templates/vhosts.conf.j2
@@ -144,6 +144,9 @@ RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
   SSLCertificateFile /etc/pki/tls/certs/www_tieteentermipankki_fi_cert.cer
   SSLCertificateKeyFile /etc/pki/tls/private/www_tieteentermipankki_fi.key
   SSLCertificateChainFile /etc/pki/tls/certs/GEANT_OV_RSA_CA_4.cer
+  SSLCertificateFile  "{{ acme_root }}/live/tieteentermipankki.fi/cert.pem"
+  SSLCertificateKeyFile "{{ acme_root }}/live/tieteentermipankki.fi/privkey.pem"
+  SSLCertificateChainFile  "{{ acme_root }}/live/tieteentermipankki.fi/chain.pem"
 
   <Directory "/www/tieteentermipankki.fi/docroot">
     AllowOverride All


### PR DESCRIPTION
Manage cert for tieteentermipankki using ACME. As we support both www.tieteentermipankki.fi and tieteentermipankki.fi, support for multiple domains per certificate was added.

WAITING FOR https://github.com/CSCfi/Kielipankki-palvelut/pull/54: should not be merged before it