### PR TITLE
KP-7076 Add provisioning for a bare Alma9 VM on Pouta

### DIFF
--- a/commandline/README.md
+++ b/commandline/README.md
@@ -16,7 +16,7 @@ See site.yml for details.
 
 In testing mode the script "installs" the tools to a temporary directory, see inventories/test for details. To selectively install, use tags, e.g.:
 
-ansible-playbook -i test site.yml -t tsv-utils
+ansible-playbook -i inventories/csc_test site.yml -t tsv-utils
 ssh puhti-login2.csc.fi (check host in inventories/test)
 module use /local_scratch/<uid>/ansible/modulefiles  (check module_root in inventories/test)
 
@@ -53,7 +53,7 @@ A long term solution is to adjust the roles and/or the invocation (e.g. use of `
 In production the installation target is Kielipankki's software
 environment below /appl/soft/ling/. 
 
-ansible-playbook -i production site.yml 
+ansible-playbook -i inventories/production site.yml 
 
 # Partial installation
 

--- a/servers/sanat/.gitignore
+++ b/servers/sanat/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 *.retry
+project_*-openrc.sh

--- a/servers/sanat/README.md
+++ b/servers/sanat/README.md
@@ -1,11 +1,31 @@
 ## Prerequisites
 
- - A Centos 7 fresh install (tested on fresh CSC install)
+### Creating the VM
+ - Python 3 (tested on 3.10) and required packages:
+```
+virtualenv -p python3 .venv
+source .venv/bin/activate
+pip install -r requirements_dev.txt
+```
+ - Sourced Pouta openrc file for the CSC project
+ - `ansible-galaxy install -r requirements-pouta_creation.yml`
+
+
+### Setting up the service
+
  - Ansible (developed on version 2)
  - Ansible-Galaxy (developed on version 2)
   - `ansible-galaxy install -r requirements.yml`)
 
 ## Usage
+
+### Creating the VM
+
+```
+ansible-playbook -i inventories/pouta create-vm.yml
+```
+
+### Setting up the service
 
  - `ansible-playbook -i inventories/development site.yml`
  - After completed setup, initialize the database and update, eg:
@@ -16,7 +36,7 @@
 
  - Cloning the MediaWiki code can take a long time, depending on network speed
  - Set Selinux to at least permissive, this script does not yet support it
- 
+
 ## Example for bootstrapping an empty wiki database
 
   - `cd /srv/mediawiki/SITE/workdir`

--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -13,7 +13,7 @@
       - ajarven
       - matthies
       - shardwic
-      # TODO add Niklas
+      - nlaxstrom
     servers:
       - name: sanat
         image: AlmaLinux-9

--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -1,0 +1,66 @@
+---
+
+- name: Create virtual machine on cPouta
+  hosts: localhost
+  remote_user: almalinux
+  become: false
+
+  vars:
+    project_sg: sanat-sg
+    project_security_groups: "default,{{project_sg}}"
+    authorized_users:
+      - ktegel
+      - ajarven
+      - matthies
+      - shardwic
+      # TODO add Niklas
+    servers:
+      - name: sanat
+        image: AlmaLinux-9
+        flavor: standard.medium
+        key_name: kielipouta
+        security_groups: "{{project_security_groups}}"
+        meta:
+          group: default
+
+    security_group_rules:
+      - name: ping
+        protocol: icmp
+        port: -1
+        allowed_ips:
+          - "193.167.254.68/32"  # opsview
+
+      - name: nagios
+        protocol: tcp
+        port: 5666
+        allowed_ips:
+          - "193.167.254.68/32"  # opsview
+
+      - name: http
+        protocol: tcp
+        port: 80
+        allowed_ips:
+          - "192.168.1.0/24"  # pouta local network
+
+      - name: ssh
+        protocol: tcp
+        port: 22
+        allowed_ips:
+          - "193.166.1.0/24"  # CSC Office
+          - "193.166.2.0/24"  # CSC Office
+          - "193.166.84.0/24"  # CSC VPN
+          - "193.166.85.0/24"  # CSC VPN
+
+  roles:
+    - role: kielipankki.common.create_instances
+      tags: create_instances
+
+
+- name: Install CSC basics
+  hosts: web
+  become: true
+  roles:
+    - role: kielipankki.common.postfix
+      tags: postfix
+    - role: kielipankki.common.opsview
+      tags: opsview

--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -46,6 +46,7 @@
         protocol: tcp
         port: 22
         allowed_ips:
+          - "95.216.214.203/32" # Niklas Laxström
           - "193.166.1.0/24"  # CSC Office
           - "193.166.2.0/24"  # CSC Office
           - "193.166.84.0/24"  # CSC VPN

--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -17,7 +17,7 @@
     servers:
       - name: sanat
         image: AlmaLinux-9
-        flavor: standard.medium
+        flavor: standard.large
         key_name: kielipouta
         security_groups: "{{project_security_groups}}"
         meta:

--- a/servers/sanat/inventories/pouta
+++ b/servers/sanat/inventories/pouta
@@ -1,5 +1,9 @@
-[web]
-vm0623.kaj.pouta.csc.fi webdomain_sanat=vm0623.kaj.pouta.csc.fi ansible_user=cloud-user
-
-[pouta:children]
-web
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      floating_ip: 128.214.255.214
+      ansible_python_interpreter: python
+    web:
+      ansible_host: 128.214.255.214
+      ansible_user: almalinux

--- a/servers/sanat/requirements-pouta_creation.yml
+++ b/servers/sanat/requirements-pouta_creation.yml
@@ -1,0 +1,6 @@
+---
+
+collections:
+  - name: git@github.com:CSCfi/Kielipankki-ansible-common.git
+    type: git
+    version: main

--- a/servers/sanat/requirements_dev.txt
+++ b/servers/sanat/requirements_dev.txt
@@ -1,0 +1,5 @@
+python-openstackclient==3.14.3
+shade
+ansible
+dnspython
+openstacksdk<=0.98.99


### PR DESCRIPTION
After this PR, it should be easy to create an empty VM for Sanat use on Pouta. VM creation (done by CSC) and software installations etc (done by external people) are intentionally kept separate so that it's not necessary to have the privileges to run both to run one.

The old pouta inventory was harshly overwritten, as the machine referred there does not seem to be ours anymore.

TODO:
- [x] SSH key for Niklas
- [x] security group rule adjustments
- [x] ~backing up~ [KP-8465](https://jira.eduuni.fi/browse/KP-8465)
- [x] ~fix opsview~ [KP-8466](https://jira.eduuni.fi/browse/KP-8466)