### PR TITLE
KP-9086 Heliots 2.0 + housekeeping

### DIFF
--- a/commandline/README.md
+++ b/commandline/README.md
@@ -9,7 +9,7 @@ This script installs tools to HPC, like:
  * ffmpeg
  * libxml2, xslt1
  * kaldi
- 
+
 See site.yml for details.
 
 # Testing
@@ -51,9 +51,9 @@ A long term solution is to adjust the roles and/or the invocation (e.g. use of `
 # Production
 
 In production the installation target is Kielipankki's software
-environment below /appl/soft/ling/. 
+environment below /appl/soft/ling/.
 
-ansible-playbook -i inventories/production site.yml 
+ansible-playbook -i inventories/production site.yml
 
 # Partial installation
 
@@ -62,4 +62,3 @@ site.yml for details, see example in Testing above.
 
 # Modulefiles
 Note that module files are not created by all scripts, those who do have a template/module_template.j2 present.
-

--- a/commandline/README.md
+++ b/commandline/README.md
@@ -15,10 +15,11 @@ See site.yml for details.
 # Testing
 
 In testing mode the script "installs" the tools to a temporary directory, see inventories/test for details. To selectively install, use tags, e.g.:
-
-ansible-playbook -i inventories/csc_test site.yml -t tsv-utils
-ssh puhti-login2.csc.fi (check host in inventories/test)
-module use /local_scratch/<uid>/ansible/modulefiles  (check module_root in inventories/test)
+```
+ansible-playbook -i inventories/test_csc site.yml -t tsv-utils
+ssh puhti-login12.csc.fi  # (check host in inventories/test_csc)
+module use /local_scratch/<uid>/ansible/modulefiles  # (check module_root in inventories/test)
+```
 
 ## Local installation
 

--- a/commandline/heliots/defaults/main.yml
+++ b/commandline/heliots/defaults/main.yml
@@ -2,11 +2,10 @@
 # defaults
 
 package_name: heliots
-heliots_version: 1.3
+heliots_version: 2.0
 version: "{{ heliots_version }}"
 jar_name: "heliots-{{ heliots_version }}.jar"
-source_url: https://zenodo.org/record/6077089/files/HeLI.jar?download=1
+source_url: https://zenodo.org/records/10907468/files/HeLI.jar
 install_dir: "{{ install_prefix }}/ling/{{ package_name }}/{{ version }}"
 lib_dir: "{{ install_dir }}/lib"
 module_path: "{{ module_root }}/{{ package_name }}"
-

--- a/commandline/heliots/tasks/main.yml
+++ b/commandline/heliots/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Download jar
   get_url:
     url: "{{ source_url }}"
-    dest: "{{ install_dir }}/lib/{{ jar_name }}"
+    dest: "{{ lib_dir }}/{{ jar_name }}"
     mode: "g+rwX,o+rX"
 
 

--- a/commandline/heliots/tasks/main.yml
+++ b/commandline/heliots/tasks/main.yml
@@ -30,7 +30,7 @@
   template:
     src: module_template.j2
     dest: "{{ module_path }}/{{ version }}.lua"
-    mode: 0644
+    mode: 0664
 
 
 - name: Fix permissions (if shared group is set)

--- a/commandline/heliots/tasks/main.yml
+++ b/commandline/heliots/tasks/main.yml
@@ -2,9 +2,9 @@
 
 - name: Ensure directories exist
   become: no
-  command:
-    cmd: mkdir -p "{{ item }}"
-    creates: "{{ item }}"
+  file:
+    path: "{{ item }}"
+    state: directory
   loop:
     # - "{{ src_root }}"
     - "{{ install_dir }}/bin"

--- a/commandline/heliots/tasks/main.yml
+++ b/commandline/heliots/tasks/main.yml
@@ -9,7 +9,7 @@
     # - "{{ src_root }}"
     - "{{ install_dir }}/bin"
     - "{{ lib_dir }}"
-    -  "{{ module_path }}"
+    - "{{ module_path }}"
 
 - name: Download jar
   get_url:

--- a/commandline/heliots/tasks/main.yml
+++ b/commandline/heliots/tasks/main.yml
@@ -2,10 +2,9 @@
 
 - name: Ensure directories exist
   become: no
-  command: mkdir -p "{{ item }}"
-  args:
+  command:
+    cmd: mkdir -p "{{ item }}"
     creates: "{{ item }}"
-    warn: false
   loop:
     # - "{{ src_root }}"
     - "{{ install_dir }}/bin"

--- a/commandline/roles/hunpos/tasks/main.yml
+++ b/commandline/roles/hunpos/tasks/main.yml
@@ -2,10 +2,9 @@
 
 - name: Ensure directories exists
   become: no
-  command: mkdir -p "{{ item }}"
-  args:
-    creates: "{{ item }}"
-    warn: false
+  file:
+    path: "{{ item }}"
+    state: directory
   loop:
     - "{{ src_root }}"
     - "{{ install_dir }}/bin"

--- a/commandline/roles/sparv_pipeline/tasks/main.yml
+++ b/commandline/roles/sparv_pipeline/tasks/main.yml
@@ -2,10 +2,9 @@
 
 - name: Ensure directories exists
   become: no
-  command: mkdir -p "{{ item }}"
-  args:
-    creates: "{{ item }}"
-    warn: false
+  file:
+    path: "{{ item }}"
+    state: directory
   loop:
     - "{{ src_root }}"
     - "{{ install_dir }}/jars/lib"
@@ -26,14 +25,14 @@
     accept_hostkey: yes
     force: yes
   loop: "{{ kuhumcst_git_pkgs }}"
-  
+
 - name: set cstlemma STREAM
   lineinfile:
     path: "{{ src_root }}/cstlemma/src/defines.h"
     regexp: "^#define STREAM 0"
     line: "#define STREAM 1 // 0: use stdio 1: use iostream"
 
-- name: make cstlemma 
+- name: make cstlemma
   shell: bash --login -c "{{ gcc_modcall }} make  > MAKE.log"
   args:
     chdir: "{{ src_root }}/cstlemma/src"
@@ -49,7 +48,7 @@
   shell: cat {suc,saldo}.cstlemma.lemmas > suc-saldo.cstlemma.lemmas
   args:
     chdir: "{{ compile_dir }}/annotate/models/"
-   
+
 - name: compile cstlemma dicts
   shell: bash --login -c "{{ install_dir }}/bin/cstlemma -D -c FBT -e 1  -i {{ item }}.cstlemma.lemmas -o {{ item }}.cstlemma.dict"
   args:

--- a/commandline/site.yml
+++ b/commandline/site.yml
@@ -23,7 +23,6 @@
       - TurkuNLP/bert-base-finnish-cased-v1
       - TurkuNLP/bert-base-finnish-uncased-v1
    - tsv_tools_version: 2.2.0
-   - heliots_version: 1.3
    - vrt_tools_version: 1.0
 
 

--- a/commandline/site.yml
+++ b/commandline/site.yml
@@ -9,47 +9,60 @@
    - finnish_parse_version: 1.0
    - praat_version: 6.4
    - finnish_tagtools_version: 1.6.0
-#   - kaldi_version:
-#      number: 5.5.219
-#      githash:  06bf62a57
+   # - kaldi_version:
+   #    number: 5.5.219
+   #    githash:  06bf62a57
    - aalto_asr_version:
-       number: 2.1
-       githash: latest
+      number: 2.1
+      githash: latest
    - hunpos_version: 1.0
    - sparv_pipeline_version: 2.0_MIT_2017-10-23
-#  - ffmpeg_version: see roles/ffmpeg/defaults/main.yml
+   # - ffmpeg_version: see roles/ffmpeg/defaults/main.yml
    - udpipe_version: 1.2.0
    - bert_models:
-       - TurkuNLP/bert-base-finnish-cased-v1
-       - TurkuNLP/bert-base-finnish-uncased-v1
+      - TurkuNLP/bert-base-finnish-cased-v1
+      - TurkuNLP/bert-base-finnish-uncased-v1
    - tsv_tools_version: 2.2.0
    - heliots_version: 1.3
    - vrt_tools_version: 1.0
-      
+
 
   become: no
   gather_facts: true
   gather_subset: min
   roles:
-   - { role: hfst, tags: hfst }
-   - { role: hfst-morphologies, tags: hfst-morphologies }
-   - { role: hfst-ospell, tags: hfst-ospell }
-   - { role: check-hfst, tags: check-hfst }
-   - { role: finnish-parse, branch: master, tags: finnish-parse }
-   - { role: praat, tags: praat }
-# disabled, managed with Spack now
-#   - { role: ffmpeg, branch: master, tags: ffmpeg }
-#   - { role: kaldi    , tags: kaldi }
-   - { role: aalto-asr, tags: aalto-asr }
-   - { role: udpipe, tags: udpipe }
-   - { role: hunpos, tags: hunpos }
-   - { role: sparv_pipeline, tags: sparv_pipeline }
-#   - { role: bert_models , tags: bert_models }
-- { import_playbook: heliots/heliots.yml , tags: heliots }
-- { import_playbook: vrt-tools/vrt-tools.yml , tags: vrt-tools }
-- { import_playbook: tsv-utils/tsv-utils.yml , tags: tsv-utils }
-- { import_playbook: finnish-tagtools/finnish-tagtools.yml , tags: finnish-tagtools }
+   - role: hfst
+     tags: hfst
+   - role: hfst-morphologies
+     tags: hfst-morphologies
+   - role: hfst-ospell
+     tags: hfst-ospell
+   - role: check-hfst
+     tags: check-hfst
+   - role: finnish-parse
+     branch: master
+     tags: finnish-parse
+   - role: praat
+     tags: praat
+   # disabled, managed with Spack now
+   # - { role: ffmpeg, branch: master, tags: ffmpeg }
+   # - { role: kaldi    , tags: kaldi }
+   - role: aalto-asr
+     tags: aalto-asr
+   - role: udpipe
+     tags: udpipe
+   - role: hunpos
+     tags: hunpos
+   - role: sparv_pipeline
+     tags: sparv_pipeline
+   # - { role: bert_models , tags: bert_models }
 
 
-
-     
+- import_playbook: heliots/heliots.yml
+  tags: heliots
+- import_playbook: vrt-tools/vrt-tools.yml
+  tags: vrt-tools
+- import_playbook: tsv-utils/tsv-utils.yml
+  tags: tsv-utils
+- import_playbook: finnish-tagtools/finnish-tagtools.yml
+  tags: finnish-tagtools


### PR DESCRIPTION
Updated the playbook to install version 2.0 of HeLI-OTS and did some housekeeping on the relevant parts of the codebase on the side. The housekeeping tasks included:
- ansible-lint
- readme improvements
- syntax compatible with newer Ansible versions (old syntax might still be present in other tasks)
- use ready-made modules instead of command line commands where possible

When the playbook is run as
```
(.venv) vagrant@kpdev:~/scratch/kielipankki-palvelut/commandline$ ansible-playbook site.yml -i inventories/test_csc -t heliots --extra-vars=ansible_ssh_user=jarvenp2
```
it produces an usable local installation on Puhti:
```
[jarvenp2@puhti-login12 ~]$ module use /local_scratch/jarvenp2/ansible/modulefiles/
[jarvenp2@puhti-login12 ~]$ module load heliots/2.0 
[jarvenp2@puhti-login12 ~]$ cat testi.txt 
hejssan, jag heter Peter
saluton, mia nomo estas Essi
[jarvenp2@puhti-login12 ~]$ heliots -r testi.txt -w out.txt; cat out.txt
swe
epo
```