### PR TITLE
KP-8465 Add rule to let korp3.csc.fi ssh in to sanat

### DIFF
--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -58,6 +58,12 @@
         allowed_ips:
           - "0.0.0.0/0"
 
+     - name: ssh
+       protocol: tcp
+       port: 22
+       allowed_ips:
+         - "86.50.56.187/32" # korp3.csc.fi needs to fetch backups
+
   roles:
     - role: kielipankki.common.create_instances
       tags: create_instances


### PR DESCRIPTION
Our intended backup process is now for korp3 to ssh in, fetch backups from machines, and then korp3 gets backed up. To support that in sanat, we need to add a security group rule for this.