### PR TITLE
KP-7735 Install openSMILE 3.0.2 with FFmpeg support on Puhti

### DIFF
--- a/commandline/roles/opensmile/defaults/main.yml
+++ b/commandline/roles/opensmile/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# defaults
 
 package_name: openSMILE
 version: 3.0.2
@@ -7,5 +6,5 @@ source_url: "https://github.com/audeering/opensmile/archive/refs/tags/v{{ versio
 src_root: "/local_scratch/{{ ansible_ssh_user }}/ansible/build/{{ package_name }}"
 build_dir: "{{ src_root }}/opensmile-{{ version }}/"
 opensmile_build_modcall: ". /appl/profile/zz-csc-env.sh && module load gcc && module load ffmpeg &&"
-install_dir: "{{ install_prefix }}/ling/{{ package_name }}/{{ version }}/bin"
-#module_path: "{{ module_root }}/{{ package_name }}"
+install_dir: "{{ install_prefix }}/ling/{{ package_name }}/{{ version }}"
+module_path: "{{ module_root }}/{{ package_name }}"

--- a/commandline/roles/opensmile/defaults/main.yml
+++ b/commandline/roles/opensmile/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# defaults
+
+package_name: openSMILE
+version: 3.0.2
+source_url: "https://github.com/audeering/opensmile/archive/refs/tags/v{{ version }}.tar.gz"
+src_root: "/local_scratch/{{ ansible_ssh_user }}/ansible/build/{{ package_name }}"
+build_dir: "{{ src_root }}/opensmile-{{ version }}/"
+opensmile_build_modcall: ". /appl/profile/zz-csc-env.sh && module load gcc && module load ffmpeg &&"
+install_dir: "{{ install_prefix }}/ling/{{ package_name }}/{{ version }}/bin"
+#module_path: "{{ module_root }}/{{ package_name }}"

--- a/commandline/roles/opensmile/defaults/main.yml
+++ b/commandline/roles/opensmile/defaults/main.yml
@@ -5,6 +5,6 @@ version: 3.0.2
 source_url: "https://github.com/audeering/opensmile/archive/refs/tags/v{{ version }}.tar.gz"
 src_root: "/local_scratch/{{ ansible_ssh_user }}/ansible/build/{{ package_name }}"
 build_dir: "{{ src_root }}/opensmile-{{ version }}/"
-opensmile_build_modcall: ". /appl/profile/zz-csc-env.sh && module load gcc && module load ffmpeg &&"
+opensmile_build_modcall: ". /appl/profile/zz-csc-env.sh && module load gcc && module load ffmpeg/4.4.1 &&"
 install_dir: "{{ install_prefix }}/ling/{{ package_name }}/{{ version }}"
 module_path: "{{ module_root }}/{{ package_name }}"

--- a/commandline/roles/opensmile/tasks/main.yml
+++ b/commandline/roles/opensmile/tasks/main.yml
@@ -7,8 +7,7 @@
   loop:
     - "{{ src_root }}"
     - "{{ install_dir }}"
-#    - "{{ module_path }}"
-
+    - "{{ module_path }}"
 
 - name: Get source
   ansible.builtin.unarchive:
@@ -43,3 +42,9 @@
   ansible.builtin.file:
     path: "{{ build_dir }}"
     state: absent
+
+- name: Create lmod module
+  ansible.builtin.template:
+    src: module_template.j2
+    dest: "{{ module_path }}/{{version}}.lua"
+    mode: 0664

--- a/commandline/roles/opensmile/tasks/main.yml
+++ b/commandline/roles/opensmile/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Ensure necessary directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "{{ src_root }}"
+    - "{{ install_dir }}"
+#    - "{{ module_path }}"
+
+
+- name: Get source
+  ansible.builtin.unarchive:
+    src: "{{ source_url }}"
+    dest: "{{ src_root }}"
+    remote_src: true
+    creates: "{{ build_dir }}"
+
+- name: Set custom build flags
+  ansible.builtin.lineinfile:
+    path: "{{ build_dir }}/build_flags.sh"
+    regexp: "\\s*{{ item.flag }}="
+    line: "{{ item.new_line }}"
+  loop:
+    - {flag: DWITH_FFMPEG, new_line: "    -DWITH_FFMPEG=ON"}
+    - {flag: DMARCH_NATIVE, new_line: "    -DMARCH_NATIVE=ON"}
+
+- name: Build
+  ansible.builtin.shell:
+    cmd: /bin/bash -lc "{{ opensmile_build_modcall }} /bin/bash build.sh"
+    chdir: "{{ build_dir }}"
+    creates: "{{ build_dir }}/build/progsrc/smilextract/SMILExtract"
+
+- name: Copy executable to final location
+  ansible.builtin.copy:
+    src: "{{ build_dir }}/build/progsrc/smilextract/SMILExtract"
+    dest: "{{ install_dir }}"
+    mode: 0755
+    remote_src: true
+
+- name: Remove build directory
+  ansible.builtin.file:
+    path: "{{ build_dir }}"
+    state: absent

--- a/commandline/roles/opensmile/templates/module_template.j2
+++ b/commandline/roles/opensmile/templates/module_template.j2
@@ -1,0 +1,11 @@
+help([[
+{{ package_name }} with FFmpeg support for additional audio formats.
+
+For documentation, see https://audeering.github.io/opensmile/index.html.
+]])
+
+local   version =       '{{ version }}'
+local   prog_root =     '{{ install_dir }}'
+
+prepend_path('PATH', prog_root)
+depends_on('ffmpeg/4.4.1')

--- a/commandline/site.yml
+++ b/commandline/site.yml
@@ -42,6 +42,7 @@
    - { role: hunpos, tags: hunpos }
    - { role: sparv_pipeline, tags: sparv_pipeline }
    - { role: enchant, tags: enchant }
+   - { role: opensmile, tags: opensmile }
 #   - { role: bert_models , tags: bert_models }
 # disabled, managed with Spack now
 #   - { role: ffmpeg, branch: master, tags: ffmpeg }


### PR DESCRIPTION
This has been tested on a personal installation with example data provided by openSMILE (see Jira for attached files):
```
[jarvenp2@puhti-login12 ~]$ module use /local_scratch/jarvenp2/ansible/modulefiles
[jarvenp2@puhti-login12 ~]$ module load openSMILE
[jarvenp2@puhti-login12 ~]$ cd tmp/smile/
[jarvenp2@puhti-login12 smile]$ SMILExtract -C demo1_energy.conf -I opensmile.wav -O test_output.csv
(MSG) [2] SMILExtract: openSMILE starting!
(MSG) [2] SMILExtract: config file is: demo1_energy.conf
(MSG) [2] cComponentManager: successfully registered 103 component types.
(MSG) [2] cComponentManager: successfully finished createInstances (4 component instances were finalised, 1 data memories were finalised)
(MSG) [2] cComponentManager: starting single thread processing loop
(MSG) [2] cComponentManager: Processing finished! System ran for 205 ticks.
[jarvenp2@puhti-login12 smile]$ head -n 2 test_output.csv 
frameIndex;frameTime;pcm_LOGenergy
0;0.000000;-1.383729e+01
```
as well as with a non-wav input file (requiring FFmpeg support) and configuration modified to use it:
```
[jarvenp2@puhti-login12 smile]$ SMILExtract -C ffmpeg.conf -I opensmile.flac 
(MSG) [2] SMILExtract: openSMILE starting!
(MSG) [2] SMILExtract: config file is: ffmpeg.conf
(MSG) [2] cComponentManager: successfully registered 103 component types.
==> LEVEL 'ffmpeg'  +++  Buffersize(frames) = 88201  +++  nReaders = 1
==> LEVEL 'frames'  +++  Buffersize(frames) = 3  +++  nReaders = 1
==> LEVEL 'energy'  +++  Buffersize(frames) = 3  +++  nReaders = 1
(MSG) [2] cComponentManager: successfully finished createInstances (4 component instances were finalised, 1 data memories were finalised)
(MSG) [2] cComponentManager: starting single thread processing loop
(MSG) [2] cComponentManager: Processing finished! System ran for 84 ticks.
[jarvenp2@puhti-login12 smile]$ head -n 2 opensmile.energy.csv 
frameIndex;frameTime;pcm_LOGenergy
0;0.000000;-1.383729e+01

```