### PR TITLE
Kp 9548 dnf automatic

### DIFF
--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -5,63 +5,9 @@
   remote_user: almalinux
   become: false
 
-  vars:
-    sg_custom_ssh_ips:
-      - "95.216.214.203/32" # Niklas Laxström
-      - "86.50.31.6/32"     # Korp2
-      - "86.50.56.187/32"   # Korp3
-
-    authorized_users:
-      - ktegel
-      - ajarven
-      - matthies
-      - shardwic
-      - nlaxstrom
-
-    instance_name: sanat
-    pouta_instance_name: "{{ instance_name }}-{{ vm_name_postfix }}"
-    project_key: kielipouta
-    project_sg: sanat-sg
-    project_security_groups: default,{{ project_sg }}  # don't add spaces here!
-    std_image: "AlmaLinux-9"
-    flavor: "standard.large"
-    network: "project_2000680"
-
-    servers:
-      - name: "{{ pouta_instance_name }}"
-        image: "{{ std_image }}"
-        flavor: "{{ flavor }}"
-        key_name: "{{ project_key }}"
-        security_groups: "{{ project_security_groups }}"
-        network: "{{ network }}"
-        meta:
-          hostname: "{{ pouta_instance_name }}"
-          group:    "{{ pouta_instance_name }}"
-
-
-    security_group_rules:
-      - name: ping
-        protocol: icmp
-        port: -1
-        allowed_ips:
-          - "193.167.254.68/32"  # opsview
-
-      - name: http
-        protocol: tcp
-        port: 80
-        allowed_ips:
-          - "0.0.0.0/0"
-
-      - name: https
-        protocol: tcp
-        port: 443
-        allowed_ips:
-          - "0.0.0.0/0"
-
   roles:
     - role: kielipankki.common.create_instances
       tags: create_instances
-
 
 - name: Install CSC basics
   hosts: web

--- a/servers/sanat/host_vars/localhost.yml
+++ b/servers/sanat/host_vars/localhost.yml
@@ -1,0 +1,57 @@
+# "localhost" variables are used mostly by pouta-vm related tasks
+#
+# The following variables need to be defined in the inventory
+#
+# - vm_name_postfix (e.g. "prod")
+# - flavor (e.g. "standard.large")
+
+sg_custom_ssh_ips:
+  - "95.216.214.203/32" # Niklas Laxström
+  - "86.50.31.6/32"     # Korp2
+  - "86.50.56.187/32"   # Korp3
+
+authorized_users:
+  - ktegel
+  - ajarven
+  - matthies
+  - shardwic
+  - nlaxstrom
+
+instance_name: sanat
+pouta_instance_name: "{{ instance_name }}-{{ vm_name_postfix }}"
+project_key: kielipouta
+project_sg: sanat-sg
+project_security_groups: default,{{ project_sg }}  # don't add spaces here!
+std_image: "AlmaLinux-9"
+network: "project_2000680"
+
+servers:
+  - name: "{{ pouta_instance_name }}"
+    image: "{{ std_image }}"
+    flavor: "{{ flavor }}"
+    key_name: "{{ project_key }}"
+    security_groups: "{{ project_security_groups }}"
+    network: "{{ network }}"
+    meta:
+      hostname: "{{ pouta_instance_name }}"
+      group:    "{{ pouta_instance_name }}"
+
+
+security_group_rules:
+  - name: ping
+    protocol: icmp
+    port: -1
+    allowed_ips:
+      - "193.167.254.68/32"  # opsview
+
+  - name: http
+    protocol: tcp
+    port: 80
+    allowed_ips:
+      - "0.0.0.0/0"
+
+  - name: https
+    protocol: tcp
+    port: 443
+    allowed_ips:
+      - "0.0.0.0/0"

--- a/servers/sanat/inventories/development
+++ b/servers/sanat/inventories/development
@@ -1,0 +1,11 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      floating_ip: 195.148.30.97 
+      ansible_python_interpreter: python
+      vm_name_postfix: dev
+      flavor: "standard.small"
+    web:
+      ansible_host: 195.148.30.97 
+      ansible_user: almalinux

--- a/servers/sanat/inventories/pouta-production
+++ b/servers/sanat/inventories/pouta-production
@@ -4,6 +4,8 @@ all:
       ansible_connection: local
       floating_ip: 128.214.255.214
       ansible_python_interpreter: python
+      vm_name_postfix: prod
+      flavor: standard.large
     web:
       ansible_host: 128.214.255.214
       ansible_user: almalinux


### PR DESCRIPTION
This PR accomplishes 3 things:

- create-vm.yml vars: are moved to host_vars/localhost.ym
- vm_name_postfix and flavor now have to be stated in the inventory.
- A new development inventory was created (creating a small VM for the purpose of this issue)

"sanat" was renamed to "sanat-prod" in Pouta, "sanat-dev" was successfully created using the changes proposed.