### PR TITLE
KP-9836 Make openSMILE scripts and configs available for end user

### DIFF
--- a/commandline/roles/opensmile/tasks/main.yml
+++ b/commandline/roles/opensmile/tasks/main.yml
@@ -36,6 +36,7 @@
     src: "{{ build_dir }}/build/progsrc/smilextract/SMILExtract"
     dest: "{{ install_dir }}"
     mode: 0755
+    group: p_installation
     remote_src: true
 
 - name: Copy scripts and config to final location

--- a/commandline/roles/opensmile/tasks/main.yml
+++ b/commandline/roles/opensmile/tasks/main.yml
@@ -38,6 +38,16 @@
     mode: 0755
     remote_src: true
 
+- name: Copy scripts and config to final location
+  ansible.builtin.copy:
+    src: "{{ build_dir }}/{{ item }}"
+    dest: "{{ install_dir }}"
+    group: p_installation
+    remote_src: true
+  loop:
+    - scripts
+    - config
+
 - name: Remove build directory
   ansible.builtin.file:
     path: "{{ build_dir }}"

--- a/commandline/roles/opensmile/templates/module_template.j2
+++ b/commandline/roles/opensmile/templates/module_template.j2
@@ -1,6 +1,9 @@
 help([[
 {{ package_name }} with FFmpeg support for additional audio formats.
 
+Scripts and configuration files provided by audEERING GmbH are in directories
+found in environment variables $OPENSMILE_SCRIPTS and $OPENSMILE_CONFIG.
+
 For documentation, see https://audeering.github.io/opensmile/index.html.
 ]])
 
@@ -9,3 +12,6 @@ local   prog_root =     '{{ install_dir }}'
 
 prepend_path('PATH', prog_root)
 depends_on('ffmpeg/4.4.1')
+
+setenv("OPENSMILE_SCRIPTS", pathJoin(prog_root, 'scripts'))
+setenv("OPENSMILE_CONFIG", pathJoin(prog_root, 'config'))

--- a/commandline/roles/opensmile/templates/module_template.j2
+++ b/commandline/roles/opensmile/templates/module_template.j2
@@ -1,9 +1,6 @@
 help([[
 {{ package_name }} with FFmpeg support for additional audio formats.
 
-Scripts and configuration files provided by audEERING GmbH are in directories
-found in environment variables $OPENSMILE_SCRIPTS and $OPENSMILE_CONFIG.
-
 For documentation, see https://audeering.github.io/opensmile/index.html.
 ]])
 
@@ -15,3 +12,11 @@ depends_on('ffmpeg/4.4.1')
 
 setenv("OPENSMILE_SCRIPTS", pathJoin(prog_root, 'scripts'))
 setenv("OPENSMILE_CONFIG", pathJoin(prog_root, 'config'))
+
+if(mode() == 'load')then
+        LmodMessage("")
+        LmodMessage("openSMILE loaded.")
+        LmodMessage("")
+        LmodMessage("Scripts and configuration files provided by audEERING GmbH are in directories")
+        LmodMessage("found in environment variables $OPENSMILE_SCRIPTS and $OPENSMILE_CONFIG.")
+end


### PR DESCRIPTION
Now the scripts and configs are included in `/appl/soft/ling/openSMILE` to make the accessible for the end users. Their directories can be easily accessed by using environment vars `$OPENSMILE_SCRIPTS` and `$OPENSMILE_CONF`, e.g.
```
$ module load openSMILE
$ cp -r $OPENSMILE_SCRIPTS/vad .
```