### PR TITLE
Kp 11214 termipankki mail

### DIFF
--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -15,7 +15,7 @@
   roles:
     - role: kielipankki.common.postfix
       tags: postfix
-    - role: postfix
+    - role: postfix # local role in this playbook
       tags: postfix
     - role: kielipankki.common.opsview
       tags: opsview

--- a/servers/sanat/create-vm.yml
+++ b/servers/sanat/create-vm.yml
@@ -15,5 +15,7 @@
   roles:
     - role: kielipankki.common.postfix
       tags: postfix
+    - role: postfix
+      tags: postfix
     - role: kielipankki.common.opsview
       tags: opsview

--- a/servers/sanat/roles/postfix/defaults/main.yml
+++ b/servers/sanat/roles/postfix/defaults/main.yml
@@ -7,3 +7,4 @@ postfix_config_lines:
 postfix_custom_configfiles:
  - header_checks
  - sender_canonical_maps
+ 

--- a/servers/sanat/roles/postfix/defaults/main.yml
+++ b/servers/sanat/roles/postfix/defaults/main.yml
@@ -7,4 +7,3 @@ postfix_config_lines:
 postfix_custom_configfiles:
  - header_checks
  - sender_canonical_maps
- 

--- a/servers/sanat/roles/postfix/defaults/main.yml
+++ b/servers/sanat/roles/postfix/defaults/main.yml
@@ -1,0 +1,9 @@
+postfix_config_dir: /etc/postfix/
+postfix_config_file: "{{ postfix_config_dir }}/main.cf"
+postfix_config_lines:
+ - "sender_canonical_maps = regexp:/etc/postfix/sender_canonical_maps"
+ - "sender_canonical_classes = envelope_sender, header_sender"
+ - "header_checks = regexp:/etc/postfix/header_checks"
+postfix_custom_configfiles:
+ - header_checks
+ - sender_canonical_maps

--- a/servers/sanat/roles/postfix/files/header_checks
+++ b/servers/sanat/roles/postfix/files/header_checks
@@ -1,0 +1,5 @@
+# HEADER_CHECKS(5)
+# sanat specific config, see man 5 header_checks
+
+# rewrite Kielipankki RT queue
+/^From:.*@tieteentermipankki/    REPLACE From: Tieteen termipankki <kielipankki@csc.fi>

--- a/servers/sanat/roles/postfix/files/sender_canonical_maps
+++ b/servers/sanat/roles/postfix/files/sender_canonical_maps
@@ -1,0 +1,4 @@
+# man 5 canonical
+
+# Rewrite to Kielipankki RT queue
+/^.*@tieteentermipankki.fi$/    kielipankki@csc.fi

--- a/servers/sanat/roles/postfix/tasks/main.yml
+++ b/servers/sanat/roles/postfix/tasks/main.yml
@@ -9,7 +9,7 @@
   ansible.builtin.lineinfile:
     dest: "{{ postfix_config_file }}"
     line: "{{ item }}"
-    regexp: "^{{ item | regex_replace('(^[^=]+ =)', '\\1') }}"
+    regexp: "^{{ item | regex_replace('(^[^=]+ =).*$', '\\1') }}"
     mode: "0644"
   loop: "{{ postfix_config_lines }}"
   notify: restart postfix

--- a/servers/sanat/roles/postfix/tasks/main.yml
+++ b/servers/sanat/roles/postfix/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: copy custom files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ postfix_config_dir }}"
+  loop: "{{ postfix_custom_configfiles }}"
+  notify: restart postfix
+
+- name: Update Postfix configuration
+  ansible.builtin.lineinfile:
+    dest: "{{ postfix_config_file }}"
+    line: "{{ item }}"
+    regexp: "^{{ item | regex_replace('(^[^=]+ =)', '\\1') }}"
+    mode: "0644"
+  loop: "{{ postfix_config_lines }}"
+  notify: restart postfix


### PR DESCRIPTION
This PR prevents the use of "user@tieteentermipankki.fi" and rewrites all such addreses to "kielipankki@csc.fi".
Rationale:
- tieteentermipankki.fi is not an email domain, we don't want to run a mail server for such a domain
- the RT queue ensures that undeliverable mail ends up somewhere. depending on the amount we might need to consider other addresses later.
I was torn whether to implement this more elegantly in "common", but went for this simpler approach to potentially overwrite existing config files.